### PR TITLE
Append commit authors and commiters to $contributors array correctly.

### DIFF
--- a/api/src/Changelog.php
+++ b/api/src/Changelog.php
@@ -50,7 +50,7 @@ final class Changelog
                     $commitContributors[] = $committer[0]->username;
                 }
             } catch (RequestException) {}
-            $contributors[] = $commitContributors;
+            array_push($contributors, $commitContributors);
 
             $nid = CommitParser::getNid($commit->title);
             if ($nid !== null) {


### PR DESCRIPTION
I noticed that the way commit authors and committers are getting appended to $contributors array in the Changelog class is as a nested array.

Not sure but I think this may be why the author of [this commit](https://git.drupalcode.org/project/config_readonly/-/commit/80faaf64f0c9b4f9d3c871bdfb270bb0f72d2c25
) (yours truly 🙂) was not included in the contributors list for [this release](https://www.drupal.org/project/config_readonly/releases/8.x-1.0).

I'm also not sure if this is related to (or fixes?) #164 but it seems like it might be related.