### PR TITLE
#164: Extract author & committer usernames from emails if fetching usernames from API fails.

### DIFF
--- a/api/src/Changelog.php
+++ b/api/src/Changelog.php
@@ -35,10 +35,10 @@ final class Changelog
         if (count($commits) === 0) {
             throw new \RuntimeException('No commits for the changelog to process.');
         }
+        $emailUsernameRegex = '/(?<=[0-9]-)([a-zA-Z0-9-_\.]{2,255})(?=@users\.noreply\.drupalcode\.org)/';
         $contributors = [];
         foreach ($commits as $commit) {
             $commitContributors = CommitParser::extractUsernames($commit->title);
-            $emailUsernameRegex = '/(?<=[0-9]-)([a-zA-Z0-9-_\.]{2,255})(?=@users\.noreply\.drupalcode\.org)/';
             try {
                 $author = $gitlab->users($commit->author_name);
                 if (count($author) > 0) {

--- a/api/src/Changelog.php
+++ b/api/src/Changelog.php
@@ -45,7 +45,7 @@ final class Changelog
                     $commitContributors[] = $author[0]->username;
                 }
             } catch (RequestException) {
-                if (preg_match($emailUsernameRegex, $commit->author_email, $authorMatches)){
+                if (preg_match($emailUsernameRegex, $commit->author_email, $authorMatches)) {
                     $commitContributors[] = $authorMatches[0];
                 }
             }
@@ -55,7 +55,7 @@ final class Changelog
                     $commitContributors[] = $committer[0]->username;
                 }
             } catch (RequestException) {
-                if (preg_match($emailUsernameRegex, $commit->committer_email, $committerMatches)){
+                if (preg_match($emailUsernameRegex, $commit->committer_email, $committerMatches)) {
                     $commitContributors[] = $committerMatches[0];
                 }
             }

--- a/api/src/Changelog.php
+++ b/api/src/Changelog.php
@@ -38,18 +38,27 @@ final class Changelog
         $contributors = [];
         foreach ($commits as $commit) {
             $commitContributors = CommitParser::extractUsernames($commit->title);
+            $emailUsernameRegex = '/(?<=[0-9]-)([a-zA-Z0-9-_\.]{2,255})(?=@users\.noreply\.drupalcode\.org)/';
             try {
                 $author = $gitlab->users($commit->author_name);
                 if (count($author) > 0) {
                     $commitContributors[] = $author[0]->username;
                 }
-            } catch (RequestException) {}
+            } catch (RequestException) {
+                if (preg_match($emailUsernameRegex, $commit->author_email, $authorMatches)){
+                    $commitContributors[] = $authorMatches[0];
+                }
+            }
             try {
                 $committer = $gitlab->users($commit->committer_name);
                 if (count($committer) > 0) {
                     $commitContributors[] = $committer[0]->username;
                 }
-            } catch (RequestException) {}
+            } catch (RequestException) {
+                if (preg_match($emailUsernameRegex, $commit->committer_email, $committerMatches)){
+                    $commitContributors[] = $committerMatches[0];
+                }
+            }
             $contributors[] = $commitContributors;
 
             $nid = CommitParser::getNid($commit->title);

--- a/api/tests/fixtures/views_remote_data.json
+++ b/api/tests/fixtures/views_remote_data.json
@@ -12,7 +12,7 @@
     "author_email": "mrinalini9@3611261.no-reply.drupal.org",
     "authored_date": "2022-07-13T08:56:11.000-05:00",
     "committer_name": "Matt Glaman",
-    "committer_email": "nmd.matt@gmail.com",
+    "committer_email": "27012-mglaman@users.noreply.drupalcode.org",
     "committed_date": "2022-07-13T08:56:11.000-05:00",
     "trailers": {},
     "web_url": "https://git.drupalcode.org/project/views_remote_data/-/commit/edac7fa24df524400ed40f01a2decfa0dfa847cc"
@@ -31,7 +31,7 @@
       "author_email": "mrinalini9@3611261.no-reply.drupal.org",
       "authored_date": "2022-07-13T08:56:11.000-05:00",
       "committer_name": "Matt Glaman",
-      "committer_email": "nmd.matt@gmail.com",
+      "committer_email": "27012-mglaman@users.noreply.drupalcode.org",
       "committed_date": "2022-07-13T08:56:11.000-05:00",
       "trailers": {},
       "web_url": "https://git.drupalcode.org/project/views_remote_data/-/commit/edac7fa24df524400ed40f01a2decfa0dfa847cc"

--- a/api/tests/src/ChangelogTest.php
+++ b/api/tests/src/ChangelogTest.php
@@ -38,8 +38,8 @@ class ChangelogTest extends TestCase
     {
         $mockHandler = new MockHandler([
           new Response(200, [], file_get_contents(__DIR__.'/../fixtures/views_remote_data.json')),
-          new Response(200, [], json_encode([])),
-          new Response(200, [], json_encode([])),
+          new Response(403),
+          new Response(403),
           new Response(200, [], file_get_contents(__DIR__.'/../fixtures/3294296.json')),
         ]);
         $client = new Client([
@@ -47,6 +47,11 @@ class ChangelogTest extends TestCase
         ]);
         $fixture = (new GitLab($client))->compare('views_remote_data', '1.0.1', 'HEAD');
         $sut = new Changelog($client, 'views_remote_data', $fixture->commits, '1.0.1', 'HEAD');
+        self::assertEquals([
+            'Lal_',
+            'mglaman',
+            'mrinalini9',
+        ], $sut->getContributors());
         self::assertEquals(          [
           [
             'nid' => '3294296',


### PR DESCRIPTION
Closes #164 (?)

I'm guessing the reason author and committer usernames don't seem to be able to be fetched from the GitLab API is that the users API endpoint is not public and requires authentication of some kind (https://docs.gitlab.com/ee/api/rest/#authentication).

I was confused about this at first because I found I was able to load the users endpoint in my browser but later realized that my git.drupalcode.org web session cookie was making this work (https://docs.gitlab.com/ee/api/rest/#session-cookie).

This PR adds fallback code that will try to use a regex to extract the usernames from the commit author and committer email fields when the users API endpoint is inaccessible.